### PR TITLE
Include license file in src distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include sapiens *
+include LICENSE


### PR DESCRIPTION
It would be helpful to include the license file in the source distribution.